### PR TITLE
Fix missing logger module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ node_modules/
 token.json
 
 # Logs
-logs/
+logs/*.log
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/logs/syncLogger.js
+++ b/logs/syncLogger.js
@@ -1,0 +1,16 @@
+import winston from 'winston';
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.simple(),
+  transports: [new winston.transports.Console()],
+});
+
+export default {
+  info: (...args) => logger.info(...args),
+  warn: (...args) => logger.warn(...args),
+  error: (...args) => logger.error(...args),
+  log: (...args) => logger.info(...args),
+  success: (...args) => logger.info(...args),
+  logError: (...args) => logger.error(...args),
+};


### PR DESCRIPTION
## Summary
- add a simple Winston-based logger under `logs`
- tweak `.gitignore` to keep the logger file while still ignoring log output

## Testing
- `npm test` *(fails: No valid access token found)*

------
https://chatgpt.com/codex/tasks/task_e_687a56c11bc4832f831e9df0cf177482