### PR TITLE
Fix deal lifecycle handler user field and add tests

### DIFF
--- a/sync/handlers/processPrintIQDealLifecycleWebhook.js
+++ b/sync/handlers/processPrintIQDealLifecycleWebhook.js
@@ -35,7 +35,7 @@ export function createDealLifecycleHandler({
     try {
       const payload = req.body;
       const event = payload.event?.toLowerCase();
-      const username = payload.username;
+      const username = payload.user;
 
       if (!VALID_EVENTS.includes(event)) {
         return res.status(400).send({ message: 'Unsupported event type.' });

--- a/tests/unit/dealLifecycleRetry.test.js
+++ b/tests/unit/dealLifecycleRetry.test.js
@@ -15,6 +15,7 @@ describe('deal lifecycle retry logic', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     mockDeps = {
       findDealByQuoteId: vi.fn(),
       updateDealStage: vi.fn(),

--- a/tests/unit/processPrintIQDealLifecycleWebhook.test.js
+++ b/tests/unit/processPrintIQDealLifecycleWebhook.test.js
@@ -50,6 +50,32 @@ describe('processPrintIQDealLifecycleWebhook', () => {
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
+  test('should process printIQ quote_created events', async () => {
+    const req = {
+      body: {
+        event: 'quote_created',
+        quote_id: 'Q5555',
+        status: 'Awaiting Acceptance',
+        customer_id: 'CUST555',
+        user: 'printIQ.Api.Integration',
+      },
+    };
+    const res = mockRes();
+
+    mockDeps.findDealByQuoteId.mockResolvedValue({ id: 'deal555' });
+    mockDeps.updateDealStage.mockResolvedValue({ success: true });
+
+    await handler(req, res);
+
+    expect(mockDeps.findDealByQuoteId).toHaveBeenCalledWith('Q5555');
+    expect(mockDeps.updateDealStage).toHaveBeenCalledWith(
+      'deal555',
+      'Quote Requested',
+      req.body
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
   test('should skip processing if source is not printIQ', async () => {
     const req = {
       body: {


### PR DESCRIPTION
## Summary
- use `payload.user` to identify the integration user in deal lifecycle handler
- add test coverage for `quote_created` events and suppress console errors in retry tests

## Testing
- `npm test`
- `npm run lint` *(fails: 'accountId' is defined but never used and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ca7d39308832f87ec6999b2f9de40