### PR TITLE
feat(metrics): wire middleware + basic timing and error metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ PORT=3000
 
 # Health Check Auth (Bearer token)
 HEALTH_TOKEN=your_secure_health_token_here
+# Enable metrics middleware
+ENABLE_METRICS=false

--- a/src/middleware/metrics.js
+++ b/src/middleware/metrics.js
@@ -1,12 +1,91 @@
 // src/middleware/metrics.js
 import client from 'prom-client';
+
+// Registry is always created but metrics are only collected when enabled.
 const register = new client.Registry();
-client.collectDefaultMetrics({ register });
+const isEnabled = process.env.ENABLE_METRICS === 'true';
+
+let httpRequestsTotal;
+let httpRequestDurationSeconds;
+let httpRequestErrorsTotal;
+let jobDurationSeconds;
+
+if (isEnabled) {
+  client.collectDefaultMetrics({ register });
+
+  httpRequestsTotal = new client.Counter({
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method', 'route', 'status'],
+  });
+
+  httpRequestDurationSeconds = new client.Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status'],
+    buckets: [0.05, 0.1, 0.3, 0.5, 1, 2, 5],
+  });
+
+  httpRequestErrorsTotal = new client.Counter({
+    name: 'http_request_errors_total',
+    help: 'Number of error responses (status >= 400)',
+    labelNames: ['method', 'route', 'status'],
+  });
+
+  jobDurationSeconds = new client.Histogram({
+    name: 'customer_upsert_job_duration_seconds',
+    help: 'Duration of customer upsert jobs in seconds',
+  });
+
+  [
+    httpRequestsTotal,
+    httpRequestDurationSeconds,
+    httpRequestErrorsTotal,
+    jobDurationSeconds,
+  ].forEach(m => register.registerMetric(m));
+}
+
+export function metricsMiddleware(req, res, next) {
+  if (!isEnabled) return next();
+  const start = process.hrtime.bigint();
+  res.on('finish', () => {
+    const dur = Number(process.hrtime.bigint() - start) / 1e9;
+    const labels = {
+      method: req.method,
+      route: req.route?.path || req.path || 'unknown',
+      status: String(res.statusCode),
+    };
+    httpRequestsTotal.inc(labels);
+    httpRequestDurationSeconds.observe(labels, dur);
+    if (res.statusCode >= 400) {
+      httpRequestErrorsTotal.inc(labels);
+    }
+  });
+  next();
+}
+
+function metricsHandler(_req, res) {
+  res.set('Content-Type', register.contentType);
+  register
+    .metrics()
+    .then(m => res.end(m))
+    .catch(err => res.status(500).end(String(err)));
+}
 
 export function metricsRoute(app) {
-  app.get('/metrics', async (req, res) => {
-    res.set('Content-Type', register.contentType);
-    res.end(await register.metrics());
-  });
+  if (!isEnabled) return;
+  app.get('/metrics', metricsHandler);
 }
+
+export function startTimer() {
+  const start = process.hrtime.bigint();
+  return () => Number(process.hrtime.bigint() - start) / 1e9;
+}
+
+export function observeJobDuration(seconds) {
+  if (isEnabled && jobDurationSeconds) {
+    jobDurationSeconds.observe(seconds);
+  }
+}
+
 export { register };

--- a/tests/unit/metrics.middleware.test.js
+++ b/tests/unit/metrics.middleware.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Metrics module reads env var at import time
+
+describe('metrics middleware', () => {
+  it('records request metrics', async () => {
+    process.env.ENABLE_METRICS = 'true';
+    const { metricsMiddleware, metricsRoute } = await import(
+      '../../src/middleware/metrics.js'
+    );
+    const app = express();
+    app.use(metricsMiddleware);
+    app.get('/ping', (req, res) => res.send('pong'));
+    metricsRoute(app);
+
+    await request(app).get('/ping').expect(200);
+    const res = await request(app).get('/metrics').expect(200);
+    expect(res.text).toMatch(/http_requests_total/);
+    expect(res.text).toMatch(/http_request_duration_seconds_sum/);
+  });
+});

--- a/tests/unit/worker.metrics.test.js
+++ b/tests/unit/worker.metrics.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+
+process.env.ENABLE_METRICS = 'true';
+
+const { loggerInfo, observeJobDuration } = vi.hoisted(() => ({
+  loggerInfo: vi.fn(),
+  observeJobDuration: vi.fn(),
+}));
+
+vi.mock('../../sync/auth/tokenManager.js', () => ({
+  __esModule: true,
+  getAccessToken: vi.fn().mockResolvedValue('test-token'),
+  default: { getAccessToken: vi.fn().mockResolvedValue('test-token') },
+}));
+
+vi.mock('../../src/services/zoho.client.js', () => ({
+  __esModule: true,
+  searchAccountByExternalId: vi.fn().mockResolvedValue(null),
+  createAccount: vi.fn().mockResolvedValue({ id: 'z1' }),
+  updateAccount: vi.fn(),
+}));
+
+vi.mock('../../src/mappings/customer.js', () => ({
+  __esModule: true,
+  mapCustomerToAccount: vi.fn(() => ({
+    Account_Name: 'Acme',
+    PrintIQ_Customer_ID: '1',
+  })),
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  __esModule: true,
+  logger: { info: loggerInfo },
+}));
+
+vi.mock('../../src/middleware/metrics.js', () => ({
+  __esModule: true,
+  observeJobDuration,
+  startTimer: () => () => 0.5,
+}));
+
+import { processor } from '../../src/workers/zohoWorker.js';
+
+describe('worker metrics', () => {
+  it('records processing duration', async () => {
+    await processor({ id: 'j1', data: { printiqCustomerId: 1, name: 'Acme' } });
+    expect(observeJobDuration).toHaveBeenCalledWith(0.5);
+    expect(loggerInfo).toHaveBeenCalledWith(
+      { jobId: 'j1', duration: 0.5 },
+      'worker job processed'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- integrate feature-flagged Prometheus metrics middleware and expose /metrics route
- track customer upsert worker durations and log them
- add tests for middleware and worker metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1af146588832f8426a34b76777d64